### PR TITLE
Dockerfile: Update drupal to 9.5.1-php8.0-apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drupal:9.4.8-php8.0-apache
+FROM drupal:9.5.1-php8.0-apache
 
 ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
 


### PR DESCRIPTION

Image **drupal** updated from 9.4.8-php8.0-apache to 9.5.1-php8.0-apache

**Image:** [drupal](https://hub.docker.com/r/library/drupal/)  
**Version:** 9.4.8-php8.0-apache &rarr; 9.5.1-php8.0-apache  
**Dockerfile:** Dockerfile  


If you need help or something went wrong, please comment here while mentioning me (@DockerUpBot) or use the [support formular](https://dockerup.net/support?repo=5687c2c0-86c1-471a-ae90-e4c70d41049c).

<hr>
<p align="center">
  <a href="https://dockerup.net"><img align="center" src="https://dockerup.net/img/logo.svg" alt="Docker Up" width="200px"></a>
<br>
Automated <b>Dockerfile</b> updates
</p>
	